### PR TITLE
make schedule screen closer to mocks

### DIFF
--- a/components/Schedule.tsx
+++ b/components/Schedule.tsx
@@ -138,16 +138,25 @@ function ScheduleScreen() {
               ]}
             >
               <ListItem.Content>
-                <ListItem.Title style={globalStyles.listItemTitle}>{index + " " + item.name}</ListItem.Title>
-                <ListItem.Subtitle>{item.location_name}</ListItem.Subtitle>
-                {index === 0 && index !== section.data.length - 1 && (
-                  <View style={{ height: 2, width: "100%", backgroundColor: colors.lightgrey, marginTop: 35 }} />
-                )}
+                <View style={{ flex: 1, flexDirection: "row" }}>
+                  <View style={{ paddingRight: 10 }}>
+                    <Text style={{ textAlign: "center", backgroundColor: colors.white, fontSize: 15 }}>{dayjs(item.start_time).format("h:mm A")}</Text>
+                    <Text style={{ textAlign: "center", backgroundColor: colors.white, fontSize: 15 }}>|</Text>
+                    <Text style={{ textAlign: "center", backgroundColor: colors.white, fontSize: 15 }}>{dayjs(item.start_time).format("h:mm A")}</Text>
+                  </View>
+                  <View style={{ flex: 1, flexDirection: "column", justifyContent: "space-between" }}>
+                    <ListItem.Title style={[globalStyles.listItemTitle, { fontSize: 20 }]}>{item.name}</ListItem.Title>
+                    <ListItem.Subtitle>{item.location_name}</ListItem.Subtitle>
+                    {index === 0 && index !== section.data.length - 1 && (
+                      <View style={{ height: 2, width: "100%", backgroundColor: colors.lightgrey, marginTop: 35 }} />
+                    )}
+                  </View>
+                </View>
               </ListItem.Content>
             </ListItem>
           )}
           renderSectionHeader={({ section: { title } }) => (
-            <Text style={{ textAlign: "center", backgroundColor: colors.white }}>{dayjs(title).format("h:mm A")}</Text>
+            <Text style={{ textAlign: "center", backgroundColor: colors.white, margin: 11, fontSize: 20, fontWeight: "bold" }}>{dayjs(title).format("h:mm A")}</Text>
           )}
           refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
           style={[globalStyles.scrollView, { paddingHorizontal: 8 }]}

--- a/components/Schedule.tsx
+++ b/components/Schedule.tsx
@@ -1,5 +1,5 @@
 import { createStackNavigator } from "@react-navigation/stack";
-import { RefreshControl, ScrollView, SectionList, StyleSheet, Text, View, LogBox } from "react-native";
+import { RefreshControl, ScrollView, SectionList, StyleSheet, Text, View, LogBox, Pressable } from "react-native";
 import React, { useEffect, useRef } from "react";
 import { colors, globalStyles, screenHeaderOptions } from "../global-styles";
 import { wait } from "../util";
@@ -144,11 +144,16 @@ function ScheduleScreen() {
                     <Text style={{ textAlign: "center", backgroundColor: colors.white, fontSize: 15 }}>|</Text>
                     <Text style={{ textAlign: "center", backgroundColor: colors.white, fontSize: 15 }}>{dayjs(item.start_time).format("h:mm A")}</Text>
                   </View>
-                  <View style={{ flex: 1, flexDirection: "column", justifyContent: "space-between" }}>
-                    <ListItem.Title style={[globalStyles.listItemTitle, { fontSize: 20 }]}>{item.name}</ListItem.Title>
+                  <View style={{ flex: 1, flexDirection: "column", justifyContent: "start", alignItems: "flex-start" }}>
+                    <ListItem.Title style={[globalStyles.listItemTitle, { fontSize: 20, marginBottom: 30 }]}>{item.name}</ListItem.Title>
                     <ListItem.Subtitle>{item.location_name}</ListItem.Subtitle>
+                    <Pressable onPress={() => console.log("pressed")}>
+                      <View style={{ backgroundColor: colors.lightgreen, padding: 10, marginTop: 10, borderRadius: 100 }}>
+                        <Text style={{ color: colors.white,  }}>Attending</Text>
+                      </View>
+                    </Pressable>
                     {index === 0 && index !== section.data.length - 1 && (
-                      <View style={{ height: 2, width: "100%", backgroundColor: colors.lightgrey, marginTop: 35 }} />
+                      <View style={{ height: 2, width: "100%", backgroundColor: colors.lightgrey, marginTop: 10 }} />
                     )}
                   </View>
                 </View>

--- a/components/Schedule.tsx
+++ b/components/Schedule.tsx
@@ -8,6 +8,8 @@ import CalendarStrip from "react-native-calendar-strip";
 import moment from "moment";
 import { Icon, ListItem } from "react-native-elements";
 import dayjs from "dayjs";
+import Ionicons from "react-native-vector-icons/Ionicons";
+import FeatherIcon from "react-native-vector-icons/Feather";
 
 // TODO: Get start & end date from the backend.
 export const CONFERENCE_START_DATE = moment("2021-09-24");
@@ -144,14 +146,23 @@ function ScheduleScreen() {
                     <Text style={{ textAlign: "center", backgroundColor: colors.white, fontSize: 15 }}>|</Text>
                     <Text style={{ textAlign: "center", backgroundColor: colors.white, fontSize: 15 }}>{dayjs(item.start_time).format("h:mm A")}</Text>
                   </View>
-                  <View style={{ flex: 1, flexDirection: "column", justifyContent: "start", alignItems: "flex-start" }}>
-                    <ListItem.Title style={[globalStyles.listItemTitle, { fontSize: 20, marginBottom: 30 }]}>{item.name}</ListItem.Title>
-                    <ListItem.Subtitle>{item.location_name}</ListItem.Subtitle>
-                    <Pressable onPress={() => console.log("pressed")}>
-                      <View style={{ backgroundColor: colors.lightgreen, padding: 10, marginTop: 10, borderRadius: 100 }}>
-                        <Text style={{ color: colors.white,  }}>Attending</Text>
+                  <View style={{ flexGrow: 1 }}>
+                    <View style={{ flex: 1, flexDirection: "row" }}>
+                      <View style={{ flex: 1, flexDirection: "column", justifyContent: "start", alignItems: "flex-start" }}>
+                        <ListItem.Title style={[globalStyles.listItemTitle, { fontSize: 20, marginBottom: 30 }]}>{item.name}</ListItem.Title>
+                        <ListItem.Subtitle><FeatherIcon name="map-pin" size={16} /> <Text style={{ fontSize: 16 }}>{item.location_name}</Text></ListItem.Subtitle>
+                        <Pressable onPress={() => console.log("pressed")}>
+                          <View style={{ backgroundColor: colors.lightgreen, padding: 10, marginTop: 10, borderRadius: 100 }}>
+                            <Text style={{ color: colors.white, fontWeight: "bold" }}>Attending</Text>
+                          </View>
+                        </Pressable>
                       </View>
-                    </Pressable>
+                      <Pressable onPress={() => console.log("pressed")}>
+                        <View style={{ flex: 1, justifyContent: "center", padding: 10, borderRadius: 100, height: "100%" }}>
+                          <Ionicons name="caret-forward" size={30} />
+                        </View>
+                      </Pressable>
+                    </View>
                     {index === 0 && index !== section.data.length - 1 && (
                       <View style={{ height: 2, width: "100%", backgroundColor: colors.lightgrey, marginTop: 10 }} />
                     )}

--- a/global-styles.ts
+++ b/global-styles.ts
@@ -3,9 +3,10 @@ import { StackNavigationOptions } from "@react-navigation/stack";
 
 export const colors = {
   primary: "#335CCF",
-  white: "#fff",
+  white: "#FFF",
   grey: "#888",
-  lightgrey: "#ccc",
+  lightgrey: "#CCC",
+  lightgreen: "#5CCC78"
 };
 
 export const globalStyles = StyleSheet.create({

--- a/mock-data/schedule.ts
+++ b/mock-data/schedule.ts
@@ -1,7 +1,7 @@
 export const scheduleData = [
   {
     id: 1,
-    name: "Event 1",
+    name: "Registration",
     description:
       "Pellentesque at nulla. Suspendisse potenti. Cras in purus eu magna vulputate luctus.\n\nCum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Vivamus vestibulum sagittis sapien. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.",
     start_time: "2021-09-24T17:00:01Z",
@@ -9,7 +9,7 @@ export const scheduleData = [
     attendees: ["Bob", "Jim", "Mary", "Tim", "O.J.", "Jack", "Jill", "Sandy", "Thomas", "Frank"],
     attendee_count: 10,
     attending: false,
-    location_name: "BLOC15",
+    location_name: "Anna Head Almunae Hall",
     place_id: "ChIJq6o6Q8mAj4ARsF7I2SLSZC4",
     address: "252 2nd St",
     city: "Oakland",


### PR DESCRIPTION
Why: make the schedule screen closer to mocks
What: update the components and styling without adding actual functionality

Mocks: https://www.figma.com/file/c7zVVePc56xtY0QtSJRnGd/Animal-Liberation-Conference-app?node-id=233%3A0

![image](https://user-images.githubusercontent.com/12681350/124881338-12432700-df84-11eb-894b-f56b20765af5.png)
