### PR TITLE
[#12] Grey out events on schedule once they have ended

### DIFF
--- a/components/ScheduleEvent.tsx
+++ b/components/ScheduleEvent.tsx
@@ -18,7 +18,6 @@ export function ScheduleEvent(props: Props) {
   const [submitting, setSubmitting] = useState<boolean>(false);
   const [error, setError] = useState<string>("");
   const { setData } = useContext(ScheduleContext);
-  // const currentTime = moment(new Date());
   const currentTime = moment("2021-09-25T15:00:00.000");
   const endTime = utcToLocal(props.event.start_time).add(props.event.length, "minute");
 

--- a/components/ScheduleEvent.tsx
+++ b/components/ScheduleEvent.tsx
@@ -18,7 +18,7 @@ export function ScheduleEvent(props: Props) {
   const [submitting, setSubmitting] = useState<boolean>(false);
   const [error, setError] = useState<string>("");
   const { setData } = useContext(ScheduleContext);
-  const currentTime = moment("2021-09-25T15:00:00.000");
+  const currentTime = moment(new Date());
   const endTime = utcToLocal(props.event.start_time).add(props.event.length, "minute");
 
   useEffect(() => {

--- a/components/ScheduleEvent.tsx
+++ b/components/ScheduleEvent.tsx
@@ -1,3 +1,4 @@
+import moment from "moment";
 import React, { useContext, useEffect, useState } from "react";
 import { ActivityIndicator, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { getStoredJSON, showErrorMessage, utcToLocal } from "../util";
@@ -17,6 +18,9 @@ export function ScheduleEvent(props: Props) {
   const [submitting, setSubmitting] = useState<boolean>(false);
   const [error, setError] = useState<string>("");
   const { setData } = useContext(ScheduleContext);
+  // const currentTime = moment(new Date());
+  const currentTime = moment("2021-09-25T15:00:00.000");
+  const endTime = utcToLocal(props.event.start_time).add(props.event.length, "minute");
 
   useEffect(() => {
     if (error === "") return;
@@ -85,7 +89,7 @@ export function ScheduleEvent(props: Props) {
       }
       style={{ flex: 1, flexDirection: "row" }}
     >
-      <View style={{ flexGrow: 1 }}>
+      <View style={{ flexGrow: 1, opacity: currentTime.isAfter(endTime) ? 0.4 : 1.0 }}>
         <View style={{ flex: 1, flexDirection: "row" }}>
           <View
             style={{
@@ -98,7 +102,7 @@ export function ScheduleEvent(props: Props) {
             <View style={{ flex: 1, flexDirection: "row", marginBottom: 12 }}>
               <Text style={globalStyles.textSmallMedium}>{utcToLocal(props.event.start_time).format("h:mm A")}</Text>
               <Text style={[globalStyles.textSmallMedium, { color: colors.mediumGrey }]}>
-                {"  –  " + utcToLocal(props.event.start_time).add(props.event.length, "minute").format("h:mm A")}
+                {"  –  " + endTime.format("h:mm A")}
               </Text>
             </View>
             <Text style={[globalStyles.textLargeSemiBold, { marginBottom: 2, marginRight: 12 }]}>


### PR DESCRIPTION
Why: https://github.com/dxe/alc-mobile-app/issues/12

What: grey out events on schedule once they have ended.


Tested with this date: `moment("2021-09-25T15:00:00.000")`:

![image](https://user-images.githubusercontent.com/12681350/130381148-82e18384-e76d-4de0-9ac9-7ca080c1aab8.png)
